### PR TITLE
Bump Dependency Versions

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,10 +2,10 @@
 set -eu
 
 # default versions
-HELMFILE_VER='0.132.1'
+HELMFILE_VER='0.135.0'
 HELM_PLUGIN_DIFF_VER='3.1.3'
 KIND_VERSION='0.9.0'
-KUBECTL_VERSION='1.19.2'
+KUBECTL_VERSION='1.19.4'
 
 # passed on vars
 HELM_VER="$1"

--- a/kindadm
+++ b/kindadm
@@ -2,8 +2,8 @@
 set -eu
 
 # default versions
-HELM_VER='3.4.0'
-HELM_VER_3='3.4.0'
+HELM_VER='3.4.1'
+HELM_VER_3='3.4.1'
 HELM_VER_2='2.17.0'
 
 # define vars


### PR DESCRIPTION
- `helmfile` to `v0.135.0`.
- `kubectl` to `v1.19.4`.
- Default Helm 3 to `v3.4.1`.